### PR TITLE
Federated messages models

### DIFF
--- a/SwiftSyft/Classes/SignallingMessages.swift
+++ b/SwiftSyft/Classes/SignallingMessages.swift
@@ -31,46 +31,6 @@ enum WebRTCInternalMessage {
     }
 }
 
-struct CycleRequest: Codable {
-    let workerId: UUID
-    let model: String
-    let version: String
-    let ping: String
-    let download: String
-    let upload: String
-}
-
-struct FederatedClientConfig: Codable {}
-
-struct CycleResponseSuccess: Codable {
-    let status: String
-    let requestKey: String
-    let trainingPlan: UUID
-    let clientConfig: FederatedClientConfig
-    let protocolId: UUID
-    let model: UUID
-
-    enum CodingKeys: String, CodingKey {
-        case status = "status"
-        case requestKey = "request_key"
-        case trainingPlan = "training_plan"
-        case clientConfig = "client_config"
-        case protocolId = "protocol"
-        case model = "model"
-    }
-}
-
-struct CycleResponseFailed: Codable {
-    let status: String
-    let timeout: Int
-}
-
-struct FederatedReport: Codable {
-    let workerId: String
-    let requestKey: String
-    let diff: String
-}
-
 extension WebRTCInternalMessage: Codable {
 
     // swiftlint:disable function_body_length
@@ -282,4 +242,76 @@ extension SignallingMessages: Equatable {
             return false
         }
     }
+}
+
+struct CycleRequest: Codable {
+    let workerId: UUID
+    let model: String
+    let version: String
+    let ping: String
+    let download: String
+    let upload: String
+}
+
+struct FederatedClientConfig: Codable {}
+
+struct CycleResponseSuccess: Codable {
+    let status: String
+    let requestKey: String
+    let trainingPlan: UUID
+    let clientConfig: FederatedClientConfig
+    let protocolId: UUID
+    let model: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case status = "status"
+        case requestKey = "request_key"
+        case trainingPlan = "training_plan"
+        case clientConfig = "client_config"
+        case protocolId = "protocol"
+        case model = "model"
+    }
+}
+
+struct CycleResponseFailed: Codable {
+    let status: String
+    let timeout: Int
+}
+
+// From https://medium.com/@JinwooChoi/passing-parameters-to-restful-api-with-swift-codable-d78eb78f7b1
+protocol DictionaryEncodable: Encodable {}
+extension DictionaryEncodable {
+    func dictionary() -> [String: Any]? {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        guard let json = try? encoder.encode(self),
+            let dict = try? JSONSerialization.jsonObject(with: json, options: []) as? [String: Any] else {
+                return nil
+        }
+        return dict
+    }
+}
+
+struct TrainingPlanDownloadParams: DictionaryEncodable {
+    let workerId: String
+    let requestKey: String
+    let trainingPlan: String
+}
+
+struct ProtocolDownloadParams: DictionaryEncodable {
+    let workerId: String
+    let requestKey: String
+    let protocolId: String
+}
+
+struct ModelDownloadParams: DictionaryEncodable {
+    let workerId: String
+    let requestKey: String
+    let modelId: String
+}
+
+struct FederatedReport: Codable {
+    let workerId: String
+    let requestKey: String
+    let diff: String
 }

--- a/SwiftSyft/Classes/SignallingMessages.swift
+++ b/SwiftSyft/Classes/SignallingMessages.swift
@@ -31,6 +31,46 @@ enum WebRTCInternalMessage {
     }
 }
 
+struct CycleRequest: Codable {
+    let workerId: UUID
+    let model: String
+    let version: String
+    let ping: String
+    let download: String
+    let upload: String
+}
+
+struct FederatedClientConfig: Codable {}
+
+struct CycleResponseSuccess: Codable {
+    let status: String
+    let requestKey: String
+    let trainingPlan: UUID
+    let clientConfig: FederatedClientConfig
+    let protocolId: UUID
+    let model: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case status = "status"
+        case requestKey = "request_key"
+        case trainingPlan = "training_plan"
+        case clientConfig = "client_config"
+        case protocolId = "protocol"
+        case model = "model"
+    }
+}
+
+struct CycleResponseFailed: Codable {
+    let status: String
+    let timeout: Int
+}
+
+struct FederatedReport: Codable {
+    let workerId: String
+    let requestKey: String
+    let diff: String
+}
+
 extension WebRTCInternalMessage: Codable {
 
     // swiftlint:disable function_body_length


### PR DESCRIPTION
Added models for federated learning requests, responses and download params. Should resolve #42 . No unit tests yet since the requests are not final yet.