### PR TITLE
Federated Authentication and Cycle Request using Socket Messages

### DIFF
--- a/SwiftSyft/Classes/APIPayload.swift
+++ b/SwiftSyft/Classes/APIPayload.swift
@@ -41,6 +41,11 @@ struct CycleResponseSuccess: Codable {
 struct CycleResponseFailed: Codable {
     let status: String
     let timeout: Int
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case timeout
+    }
 }
 
 // From https://medium.com/@JinwooChoi/passing-parameters-to-restful-api-with-swift-codable-d78eb78f7b1

--- a/SwiftSyft/Classes/APIPayload.swift
+++ b/SwiftSyft/Classes/APIPayload.swift
@@ -20,7 +20,7 @@ struct CycleRequest: Codable {
 
 struct FederatedClientConfig: Codable {}
 
-struct CycleResponseSuccess: Codable {
+public struct CycleResponseSuccess: Codable {
     let status: String
     let requestKey: String
     let trainingPlan: UUID

--- a/SwiftSyft/Classes/APIPayload.swift
+++ b/SwiftSyft/Classes/APIPayload.swift
@@ -7,6 +7,15 @@ struct CycleRequest: Codable {
     let ping: String
     let download: String
     let upload: String
+
+    enum CodingKeys: String, CodingKey {
+        case workerId = "worker_id"
+        case model
+        case version
+        case ping
+        case download
+        case upload
+    }
 }
 
 struct FederatedClientConfig: Codable {}

--- a/SwiftSyft/Classes/SignallingClient.swift
+++ b/SwiftSyft/Classes/SignallingClient.swift
@@ -8,8 +8,8 @@ class SignallingClient {
     private let timerProvider: Timer.Type
     private var timer: Timer?
 
-    private let messageSubject = PassthroughSubject<SignallingMessages, Never>()
-    var messagePublisher: AnyPublisher<SignallingMessages, Never> {
+    private let messageSubject = PassthroughSubject<SignallingMessagesResponse, Never>()
+    var messagePublisher: AnyPublisher<SignallingMessagesResponse, Never> {
         return messageSubject.eraseToAnyPublisher()
     }
 
@@ -36,7 +36,7 @@ extension SignallingClient: SignallingClientProtocol {
         self.socketClient.disconnect()
     }
 
-    func send(_ message: SignallingMessages) {
+    func send(_ message: SignallingMessagesRequest) {
 
         do {
             let encoder = JSONEncoder()
@@ -77,7 +77,7 @@ extension SignallingClient: SocketClientDelegate {
         case .success(let messageData):
             let decoder = JSONDecoder()
             do {
-                let message = try decoder.decode(SignallingMessages.self, from: messageData)
+                let message = try decoder.decode(SignallingMessagesResponse.self, from: messageData)
                 self.messageSubject.send(message)
             } catch let error {
                 debugPrint(error.localizedDescription)

--- a/SwiftSyft/Classes/SignallingMessages.swift
+++ b/SwiftSyft/Classes/SignallingMessages.swift
@@ -2,6 +2,10 @@ import WebRTC
 import Foundation
 
 enum SignallingMessagesRequest {
+    // Federated Learning
+    case authRequest(authToken: String?)
+    case cycleRequest(CycleRequest)
+
     case getProtocolRequest(workerId: UUID, scopeId: UUID, protocolId: String)
     case getProtocolResponse
     case joinRoom(workerId: UUID, scopeId: UUID)
@@ -17,10 +21,14 @@ enum SignallingMessagesRequest {
         case workerId
         case scopeId
         case protocolId
+        case authToken = "auth_token"
     }
 }
 
 enum SignallingMessagesResponse {
+
+    case authRequestResponse(Result<UUID, Error>)
+
     case getProtocolRequest(workerId: UUID, scopeId: UUID, protocolId: String)
     case getProtocolResponse
     case joinRoom(workerId: UUID, scopeId: UUID)
@@ -37,6 +45,15 @@ enum SignallingMessagesResponse {
         case scopeId
         case protocolId
     }
+
+    enum AuthenticationCodingKeys: String, CodingKey {
+        case workerId = "worker_id"
+        case error
+    }
+}
+
+struct AuthenticationError: Error {
+    let message: String
 }
 
 enum WebRTCInternalMessage {
@@ -193,9 +210,25 @@ extension WebRTCInternalMessage: Decodable {
 extension SignallingMessagesRequest: Encodable {
 
     // swiftlint:disable function_body_length
+    // swiftlint:disable:next cyclomatic_complexity
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
+        case .authRequest(let authToken):
+            try container.encode("federated/authenticate", forKey: .type)
+            if let authToken = authToken {
+                var dataPayloadContainer = container.nestedContainer(keyedBy: DataPayloadCodingKeys.self, forKey: .data)
+                try dataPayloadContainer.encode(authToken, forKey: .authToken)
+            }
+        case .cycleRequest(let cycleRequest):
+            try container.encode("federated/cycle-request", forKey: .type)
+            var dataPayloadContainer = container.nestedContainer(keyedBy: CycleRequest.CodingKeys.self, forKey: .data)
+            try dataPayloadContainer.encode(cycleRequest.workerId.uuidString.lowercased(), forKey: .workerId)
+            try dataPayloadContainer.encode(cycleRequest.model, forKey: .model)
+            try dataPayloadContainer.encode(cycleRequest.version, forKey: .version)
+            try dataPayloadContainer.encode(cycleRequest.ping, forKey: .ping)
+            try dataPayloadContainer.encode(cycleRequest.download, forKey: .download)
+            try dataPayloadContainer.encode(cycleRequest.upload, forKey: .upload)
         case .getProtocolRequest(let workerUUID, let scopeUUID, let protocolId):
             try container.encode("get-protocol", forKey: .type)
             var dataPayloadContainer = container.nestedContainer(keyedBy: DataPayloadCodingKeys.self, forKey: .data)
@@ -310,7 +343,19 @@ extension SignallingMessagesResponse: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
 
-        if type == "get-protocol" {
+        if type == "federated/authenticate" {
+
+            let authenticationContainer = try container.nestedContainer(keyedBy: AuthenticationCodingKeys.self, forKey: .data)
+            if let workerId = try authenticationContainer.decodeIfPresent(String.self, forKey: .workerId),
+                let workerUUID = UUID(uuidString: workerId) {
+                self = .authRequestResponse(.success(workerUUID))
+            } else if let errorString = try authenticationContainer.decodeIfPresent(String.self, forKey: .error) {
+                self = .authRequestResponse(.failure(AuthenticationError(message: errorString)))
+            } else {
+                self = .authRequestResponse(.failure(AuthenticationError(message: "Unknown Authentication Error")))
+            }
+
+        } else if type == "get-protocol" {
 
             self = .getProtocolResponse
 

--- a/SwiftSyft/Classes/SyftClient.swift
+++ b/SwiftSyft/Classes/SyftClient.swift
@@ -1,27 +1,60 @@
 import Foundation
+import Combine
 
 public class SyftClient: SyftClientProtocol {
-    let url: URL
+    private let url: URL
+    private let signallingClient: SignallingClient
 
-    public init(url: URL) {
+    init(url: URL, signallingClient: SignallingClient) {
+        self.signallingClient = signallingClient
         self.url = url
     }
 
+    convenience public init(url: URL) {
+        let signallingClient = SignallingClient(url: url, pingInterval: 30)
+        self.init(url: url, signallingClient: signallingClient)
+    }
+
     public func newJob(modelName: String, version: String) -> SyftJob {
-        return SyftJob(url: self.url, modelName: modelName, version: version)
+        return SyftJob(url: self.url,
+                       modelName: modelName,
+                       version: version,
+                       sendMessageSubject: self.signallingClient.sendMessageSubject,
+                       receiveMessagePublisher: self.signallingClient.incomingMessagePublisher)
     }
 }
 
 public class SyftJob: SyftJobProtocol {
 
     let url: URL
+    var workerUUID: UUID?
     let modelName: String
     let version: String
 
-    public init(url: URL, modelName: String, version: String) {
+    // Must be populated on `start`
+    let download: String = ""
+    let ping: String = ""
+    let upload: String = ""
+
+    var onReadyBlock: (CycleResponseSuccess) -> Void = { _ in }
+
+    private var disposeBag = Set<AnyCancellable>()
+
+    // Used to observe incoming socket messages
+    private let receiveMessagePublisher: AnyPublisher<SignallingMessagesResponse, Never>
+
+    /// Used to send message subject
+    private let sendMessageSubject: PassthroughSubject<SignallingMessagesRequest, Never>
+
+    init(url: URL, modelName: String,
+         version: String,
+         sendMessageSubject: PassthroughSubject<SignallingMessagesRequest, Never>,
+         receiveMessagePublisher: AnyPublisher<SignallingMessagesResponse, Never>) {
         self.url = url
         self.modelName = modelName
         self.version = version
+        self.sendMessageSubject = sendMessageSubject
+        self.receiveMessagePublisher = receiveMessagePublisher
     }
 
     /// Request to join a federated learning cycle at "federated/cycle-request" endpoint (https://github.com/OpenMined/PyGrid/issues/445)
@@ -42,10 +75,45 @@ public class SyftJob: SyftJobProtocol {
 
     }
 
-    public func onReady(execute: () -> Void) {
+    public func startThroughSocket(authToken: String?) {
 
-        // TODO: Subscribe to the `Subscriber` property created in `start()` and
-        // execute the block above once the subscriber is fired
+        self.sendMessageSubject.send(.authRequest(authToken: authToken))
+        self.receiveMessagePublisher.sink { [weak self] socketMessageResponse in
+
+            if let self = self {
+
+                switch socketMessageResponse {
+                case .authRequestResponse(let result):
+                    switch result {
+                    case .success(let workerUUID):
+
+                        self.workerUUID = workerUUID
+                        let cycleRequest = CycleRequest(workerId: workerUUID, model: self.modelName, version: self.version, ping: self.ping, download: self.download, upload: self.upload)
+                        self.sendMessageSubject.send(.cycleRequest(cycleRequest))
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                        return
+                    }
+                case .cycleRequestResponse(let result):
+                    switch result {
+                    case .success(let cycleSuccess):
+                        self.onReadyBlock(cycleSuccess)
+                    case .failure(let error):
+                        print(error.localizedDescription)
+                        return
+                    }
+                default:
+                    return
+                }
+
+            }
+
+        }.store(in: &self.disposeBag)
+
+    }
+
+    public func onReady(execute: @escaping (CycleResponseSuccess) -> Void) {
+        self.onReadyBlock = execute
     }
 
     /// Report the results of the learning cycle to PyGrid at "federated

--- a/SwiftSyft/Classes/SyftRTCClient.swift
+++ b/SwiftSyft/Classes/SyftRTCClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 public class SyftRTCClient {
 
@@ -6,6 +7,7 @@ public class SyftRTCClient {
     let scopeId: UUID
     let webRTCClient: WebRTCClient
     let signallingClient: SignallingClient
+    var disposeBag = Set<AnyCancellable>()
 
     init(socketURL: URL, workerId: UUID, scopeId: UUID, webRTCClient: WebRTCClient, signallingClient: SignallingClient) {
 
@@ -13,7 +15,6 @@ public class SyftRTCClient {
         self.scopeId = scopeId
         self.signallingClient = signallingClient
         self.webRTCClient = webRTCClient
-        self.signallingClient.delegate = self
 
     }
 
@@ -25,27 +26,21 @@ public class SyftRTCClient {
 
         self.init(socketURL: socketURL, workerId: workerId, scopeId: scopeId, webRTCClient: webRTClient, signallingClient: signallingClient)
 
+        let subscription = self.signallingClient.messagePublisher.sink { signallingMessage in
+            switch signallingMessage {
+            case .getProtocolResponse:
+                self.webRTCClient.start(workerId: workerId, scopeId: scopeId)
+            default:
+                self.webRTCClient.received(signallingMessage)
+            }
+        }
+        self.disposeBag.insert(subscription)
+
     }
 
     public func connect() {
-
         self.signallingClient.connect()
         self.signallingClient.send(.getProtocolRequest(workerId: self.workerId, scopeId: self.scopeId, protocolId: "50801316202"))
-    }
-
-}
-
-extension SyftRTCClient: SignallingClientDelegate {
-
-    func didReceive(_ message: SignallingMessages) {
-
-        switch message {
-        case .getProtocolResponse:
-            self.webRTCClient.start(workerId: workerId, scopeId: scopeId)
-        default:
-             self.webRTCClient.received(message)
-        }
-
     }
 
 }

--- a/SwiftSyft/Classes/SyftRTCClient.swift
+++ b/SwiftSyft/Classes/SyftRTCClient.swift
@@ -26,12 +26,12 @@ public class SyftRTCClient {
 
         self.init(socketURL: socketURL, workerId: workerId, scopeId: scopeId, webRTCClient: webRTClient, signallingClient: signallingClient)
 
-        let subscription = self.signallingClient.messagePublisher.sink { signallingMessage in
+        let subscription = self.signallingClient.incomingMessagePublisher.sink { [weak self] signallingMessage in
             switch signallingMessage {
             case .getProtocolResponse:
-                self.webRTCClient.start(workerId: workerId, scopeId: scopeId)
+                self?.webRTCClient.start(workerId: workerId, scopeId: scopeId)
             default:
-                self.webRTCClient.received(signallingMessage)
+                self?.webRTCClient.received(signallingMessage)
             }
         }
         self.disposeBag.insert(subscription)

--- a/SwiftSyft/Classes/WebRTCClient.swift
+++ b/SwiftSyft/Classes/WebRTCClient.swift
@@ -43,7 +43,7 @@ class WebRTCClient {
     private var webRTCPeers: [UUID: WebRTCPeer] = [UUID: WebRTCPeer]()
     private var workerId: UUID?
     private var scopeId: UUID?
-    private let sendSignallingMessage: (SignallingMessages) -> Void
+    private let sendSignallingMessage: (SignallingMessagesRequest) -> Void
     private let webrtcPeerFactory: (_ workerId: UUID, _ rtcPeerConnection: RTCPeerConnection, _ connectionType: WebRTCConnectionType) -> WebRTCPeer
     private let iceServers: [String]
 
@@ -55,7 +55,7 @@ class WebRTCClient {
          "stun:stun3.l.google.com:19302",
          "stun:stun4.l.google.com:19302"],
          webRTCPeerFactory: @escaping (_ workerId: UUID, _ rtcPeerConnection: RTCPeerConnection, _ connectionType: WebRTCConnectionType) -> WebRTCPeer = WebRTCPeer.init,
-         sendSignallingMessage: @escaping (SignallingMessages) -> Void) {
+         sendSignallingMessage: @escaping (SignallingMessagesRequest) -> Void) {
 
         self.workerId = workerId
         self.scopeId = scopeId
@@ -92,7 +92,7 @@ class WebRTCClient {
         self.webRTCPeers[workerUUID] = nil
     }
 
-    func received(_ signallingMessage: SignallingMessages) {
+    func received(_ signallingMessage: SignallingMessagesResponse) {
 
         switch signallingMessage {
 

--- a/SwiftSyft/Protocols/SignallingClientProtocol.swift
+++ b/SwiftSyft/Protocols/SignallingClientProtocol.swift
@@ -15,7 +15,3 @@ protocol SignallingClientProtocol {
     func send(_ message: SignallingMessages) throws
 
 }
-
-protocol SignallingClientDelegate: class {
-    func didReceive(_ message: SignallingMessages)
-}

--- a/SwiftSyft/Protocols/SignallingClientProtocol.swift
+++ b/SwiftSyft/Protocols/SignallingClientProtocol.swift
@@ -12,6 +12,6 @@ protocol SignallingClientProtocol {
 
     func connect()
     func disconnect()
-    func send(_ message: SignallingMessages) throws
+    func send(_ message: SignallingMessagesRequest) throws
 
 }

--- a/Tests/SignallingClientTests.swift
+++ b/Tests/SignallingClientTests.swift
@@ -79,8 +79,8 @@ class SignallingClientTests: XCTestCase {
     }
 
     func testSendMessageData() {
-        let message = SignallingMessages.joinRoom(workerId: UUID(), scopeId: UUID())
-        try! self.signallingClient.send(message)
+        let message = SignallingMessagesRequest.joinRoom(workerId: UUID(), scopeId: UUID())
+        self.signallingClient.send(message)
 
         let encoder = JSONEncoder()
         let messageData = try! encoder.encode(message)
@@ -91,12 +91,12 @@ class SignallingClientTests: XCTestCase {
 
     func testDeliverMessage() {
 
-        let message = SignallingMessages.joinRoom(workerId: UUID(), scopeId: UUID())
+        let message = SignallingMessagesResponse.joinRoom(workerId: UUID(), scopeId: UUID())
         let encoder = JSONEncoder()
         let messageData = try! encoder.encode(message)
 
         var didCallMessageSubscription = false
-        var messageReceived: SignallingMessages?
+        var messageReceived: SignallingMessagesResponse?
 
         let subscription = self.signallingClient.messagePublisher.sink { signallingMessage in
             didCallMessageSubscription = true

--- a/Tests/SignallingClientTests.swift
+++ b/Tests/SignallingClientTests.swift
@@ -98,7 +98,7 @@ class SignallingClientTests: XCTestCase {
         var didCallMessageSubscription = false
         var messageReceived: SignallingMessagesResponse?
 
-        let subscription = self.signallingClient.messagePublisher.sink { signallingMessage in
+        let subscription = self.signallingClient.incomingMessagePublisher.sink { signallingMessage in
             didCallMessageSubscription = true
             messageReceived = signallingMessage
         }

--- a/Tests/SignallingMessagesTests.swift
+++ b/Tests/SignallingMessagesTests.swift
@@ -22,7 +22,7 @@ extension JSONTestable where Self: Codable {
     }
 }
 
-extension SignallingMessages: JSONTestable { }
+extension SignallingMessagesResponse: JSONTestable { }
 
 class SignallingMessagesTests: XCTestCase {
 
@@ -48,28 +48,28 @@ class SignallingMessagesTests: XCTestCase {
 
     func testJoinRoomJSON() {
 
-        let joinRoom = SignallingMessages.joinRoom(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!)
+        let joinRoom = SignallingMessagesResponse.joinRoom(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!)
 
         XCTAssertEqual(joinRoomJSON, joinRoom.json())
     }
 
     func testWebrtcPeerLeftJSON() {
 
-        let peerLeft = SignallingMessages.webRTCPeerLeft(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!)
+        let peerLeft = SignallingMessagesResponse.webRTCPeerLeft(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!)
 
         XCTAssertEqual(webrtcPeerLeftJSON, peerLeft.json())
     }
 
     func testWebrtcOfferJSON() {
 
-        let offerJSON = SignallingMessages.webRTCInternalMessage(.sdpOffer(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCSessionDescription(type: .offer, sdp: "SDP_OFFER")))
+        let offerJSON = SignallingMessagesResponse.webRTCInternalMessage(.sdpOffer(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCSessionDescription(type: .offer, sdp: "SDP_OFFER")))
 
         XCTAssertEqual(webrtcOfferJSON, offerJSON.json())
 
     }
 
     func testWebrtcAnswerJSON() {
-        let offerJSON = SignallingMessages.webRTCInternalMessage(.sdpAnswer(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCSessionDescription(type: .offer, sdp: "SDP_ANSWER")))
+        let offerJSON = SignallingMessagesResponse.webRTCInternalMessage(.sdpAnswer(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCSessionDescription(type: .offer, sdp: "SDP_ANSWER")))
 
         XCTAssertEqual(webrtcAnswerJSON, offerJSON.json())
 
@@ -77,7 +77,7 @@ class SignallingMessagesTests: XCTestCase {
 
     func testWebrtcIceCandidateJSON() {
 
-        let offerJSON = SignallingMessages.webRTCInternalMessage(.iceCandidate(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCIceCandidate(sdp: "SDP_CANDIDATE", sdpMLineIndex: -1, sdpMid: nil)))
+        let offerJSON = SignallingMessagesResponse.webRTCInternalMessage(.iceCandidate(workerId: UUID(uuidString: "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed")!, scopeId: UUID(uuidString: "f0be538d-e185-47cc-ac68-27ec26088ba6")!, toId: UUID(uuidString: "5b06f42e-ee96-43e6-a6e7-e24f5a21268b")!, sdp: RTCIceCandidate(sdp: "SDP_CANDIDATE", sdpMLineIndex: -1, sdpMid: nil)))
 
         XCTAssertEqual(webrtcIceCandidateJSON, offerJSON.json())
 


### PR DESCRIPTION
Includes initial implementation for authentication and cycle request using socket messages.  Retry for failed auth request still not included because I'm not sure if that should be done as a background task.

Will put unit tests in once ping/download/upload speed are also part of syft job.