### PR TITLE
Added Pods/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ Carthage/Build
 # Note: if you ignore the Pods directory, make sure to uncomment
 # `pod install` in .travis.yml
 #
-# Pods/
+Pods/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 SwiftSyft's library structure was made using `pod lib create`. If you're not familiar with it, you can check out https://guides.cocoapods.org/making/using-pod-lib-create.
 
-You can work on the project by opening `Example/SwiftSyft.xcworkspace`. When the project is open on Xcode, you can work on the `SwiftSyft` pod itself in `Pods/Development Pods/SwiftSyft/Classes/*`
+You can work on the project by running `pod install` in the `Example` folder. Then open the file `Example/SwiftSyft.xcworkspace`. When the project is open on Xcode, you can work on the `SwiftSyft` pod itself in `Pods/Development Pods/SwiftSyft/Classes/*`
 
 ## License
 


### PR DESCRIPTION
LibTorch library is currently greater than 100 MB, the github limit so I've excluded the Pods/ folder from being committed. To run the SwiftSyft example, users must run `pod install` on their command line in the pods folder