### PR TITLE
Added type mapping from training data, validation data and model parameters to tensors

### DIFF
--- a/Example/SwiftSyft/HomeViewController.swift
+++ b/Example/SwiftSyft/HomeViewController.swift
@@ -109,8 +109,8 @@ class HomeViewController: UIViewController, UITextViewDelegate {
                         let flattenedBatch = MNISTLoader.flattenMNISTData(batchData)
                         let oneHotLabels = MNISTLoader.oneHotMNISTLabels(labels: labels).compactMap { Float($0)}
 
-                        let trainingData = TrainingData(data: flattenedBatch, shape: [clientConfig.batchSize, 784])
-                        let validationData = ValidationData(data: oneHotLabels, shape: [clientConfig.batchSize, 10])
+                        let trainingData = try TrainingData(data: flattenedBatch, shape: [clientConfig.batchSize, 784])
+                        let validationData = try ValidationData(data: oneHotLabels, shape: [clientConfig.batchSize, 10])
 
                         let loss = plan.execute(trainingData: trainingData, validationData: validationData, clientConfig: clientConfig)
                         self.lossSubject?.send(loss)

--- a/SwiftSyft/Classes/SyftPlan.swift
+++ b/SwiftSyft/Classes/SyftPlan.swift
@@ -22,7 +22,7 @@ public class TensorData<T> {
     public init(data: [T], shape: [Int]) throws {
         self.data = data
         self.shape = shape
-        if let tensorType = typeMapping[ObjectIdentifier(type(of: shape).Element.self)] {
+        if let tensorType = typeMapping[ObjectIdentifier(type(of: data).Element.self)] {
             self.tensorType = tensorType
         } else {
             throw SwiftSyftError(localizedDescription: "Unsupported type selected for array. Please use Int, Int64, Float or Double")
@@ -56,12 +56,14 @@ public class SyftPlan {
         var learningRateArray = [clientConfig.learningRate]
 
         let trainingResult = self.trainingModule.execute(withTrainingArray: &trainingDataCopy.data,
-                                    trainingShapes: trainingData.shape as [NSNumber],
-                                    trainingLabels: &validationDataCopy.data,
-                                    trainingLabelShapes: validationDataCopy.shape as [NSNumber],
-                                    paramTensorsHolder: stateTensorsHolder,
-                                    batchSize: &batchSizeArray,
-                                    learningRate: &learningRateArray)
+                                                         trainingShapes: trainingDataCopy.shape as [NSNumber],
+                                                         trainingDataType: trainingDataCopy.tensorType.rawValue,
+                                                         trainingLabels: &validationDataCopy.data,
+                                                         trainingLabelShapes: validationDataCopy.shape as [NSNumber],
+                                                         trainingLabelType: validationDataCopy.tensorType.rawValue,
+                                                         paramTensorsHolder: stateTensorsHolder,
+                                                         batchSize: &batchSizeArray,
+                                                         learningRate: &learningRateArray)
 
         let updatedParamsFloatArray = trainingResult.updatedParams.map { diff -> [Float32] in
             return diff.map { $0.floatValue }

--- a/SwiftSyft/Classes/SyftProtoExtensions.swift
+++ b/SwiftSyft/Classes/SyftProtoExtensions.swift
@@ -20,26 +20,10 @@ enum TensorType: Int {
 
 }
 
-@objc class TensorHolder: NSObject {
-    let tensorPointerValues: [NSValue]
-    let tensorData: [Data]
-    let shapes: [[Int32]]
-    let types: [Int]
-
-    init(tensorPointerValues: [NSValue], tensorData: [Data], shapes: [[Int32]], types: [Int]) {
-        self.tensorPointerValues = tensorPointerValues
-        self.tensorData = tensorData
-        self.shapes = shapes
-        self.types = types
-    }
-}
-
 extension SyftProto_Execution_V1_State {
 
-    // swiftlint:disable large_tuple
-    func getTensorData() -> (shapes: [[Int32]],
-                             tensorPointers: [NSValue],
-                             tensorData: [Data]) {
+//     swiftlint:disable large_tuple
+    func getTensorData() -> TensorsHolder {
 
         var torchTensors: [SyftProto_Types_Torch_V1_TorchTensor] = []
         var torchTensorsCount = 0
@@ -79,7 +63,9 @@ extension SyftProto_Execution_V1_State {
             }
         }
 
-        return (shapes, tensorPointerArray, tensorData)
+        let tensorsHolder = TensorsHolder(tensorPointerValues: tensorPointerArray, tensorData: tensorData, tensorShapes: shapes as [[NSNumber]], types: tensorTypes as [NSNumber])
+
+        return tensorsHolder
 
     }
 }

--- a/SwiftSyft/Classes/SyftProtoExtensions.swift
+++ b/SwiftSyft/Classes/SyftProtoExtensions.swift
@@ -9,6 +9,31 @@
 import Foundation
 import SyftProto
 
+enum TensorType: Int {
+
+    case uint32 = 1
+    case int32 = 2
+    case int64 = 3
+    case float = 4
+    case double = 5
+    case bool = 6
+
+}
+
+@objc class TensorHolder: NSObject {
+    let tensorPointerValues: [NSValue]
+    let tensorData: [Data]
+    let shapes: [[Int32]]
+    let types: [Int]
+
+    init(tensorPointerValues: [NSValue], tensorData: [Data], shapes: [[Int32]], types: [Int]) {
+        self.tensorPointerValues = tensorPointerValues
+        self.tensorData = tensorData
+        self.shapes = shapes
+        self.types = types
+    }
+}
+
 extension SyftProto_Execution_V1_State {
 
     // swiftlint:disable large_tuple
@@ -33,13 +58,19 @@ extension SyftProto_Execution_V1_State {
         var shapes: [[Int32]] = []
         var tensorData: [Data] = []
         var tensorPointerArray: [NSValue] = []
+        var tensorTypes: [Int] = []
 
         for torchTensor in torchTensors {
             switch torchTensor.contents {
             case .contentsData(let tensorHolder):
                 shapes.append(tensorHolder.shape.dims)
-                if let tensorPointerNSValue = tensorHolder.tensorPointerNSValue {
+                let (tensorPointerNSValue, tensorType) = tensorHolder.tensorPointerNSValue
+                if let tensorPointerNSValue = tensorPointerNSValue,
+                   let tensorType = tensorType {
+
                     tensorPointerArray.append(tensorPointerNSValue)
+                    tensorTypes.append(tensorType.rawValue)
+
                 }
             case .contentsBin(let data):
                 tensorData.append(data)
@@ -54,74 +85,74 @@ extension SyftProto_Execution_V1_State {
 }
 
 extension SyftProto_Types_Torch_V1_TensorData {
-    var tensorPointerNSValue: NSValue? {
+    var tensorPointerNSValue: (NSValue?, TensorType?) {
         if !contentsUint8.isEmpty {
             var copy = contentsUint8
             let tensorPointer = UnsafeMutablePointer<UInt32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.uint32)
         } else if !contentsInt8.isEmpty {
             var copy = contentsInt8
             let tensorPointer = UnsafeMutablePointer<Int32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int32)
         } else if !contentsInt16.isEmpty {
             var copy = contentsInt16
             let tensorPointer = UnsafeMutablePointer<Int32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int32)
         } else if !contentsInt32.isEmpty {
             var copy = contentsInt32
             let tensorPointer = UnsafeMutablePointer<Int32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int32)
         } else if !contentsInt64.isEmpty {
             var copy = contentsInt64
             let tensorPointer = UnsafeMutablePointer<Int64>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int64)
         } else if !contentsFloat16.isEmpty {
             var copy = contentsFloat16
             let tensorPointer = UnsafeMutablePointer<Float>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.float)
         } else if !contentsFloat32.isEmpty {
             var copy = contentsFloat32
             let tensorPointer = UnsafeMutablePointer<Float32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.float)
         } else if !contentsFloat64.isEmpty {
             var copy = contentsFloat64
             let tensorPointer = UnsafeMutablePointer<Double>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.double)
         } else if !contentsBool.isEmpty {
             var copy = contentsBool
             let tensorPointer = UnsafeMutablePointer<Bool>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.bool)
         } else if !contentsQint8.isEmpty {
             var copy = contentsQint8
             let tensorPointer = UnsafeMutablePointer<Int32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int32)
         } else if !contentsQuint8.isEmpty {
             var copy = contentsQuint8
             let tensorPointer = UnsafeMutablePointer<UInt32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.uint32)
         } else if !contentsQint32.isEmpty {
             var copy = contentsQint32
             let tensorPointer = UnsafeMutablePointer<Int32>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.int32)
         } else if !contentsBfloat16.isEmpty {
             var copy = contentsBfloat16
             let tensorPointer = UnsafeMutablePointer<Float>.allocate(capacity: copy.count)
             tensorPointer.initialize(from: &copy, count: copy.count)
-            return NSValue(pointer: tensorPointer)
+            return (NSValue(pointer: tensorPointer), TensorType.float)
         } else {
-            return nil
+            return (nil, nil)
         }
 
     }

--- a/SwiftSyft/Classes/TorchTrainingModule.h
+++ b/SwiftSyft/Classes/TorchTrainingModule.h
@@ -9,6 +9,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface TensorsHolder: NSObject
+
+@property (strong, nonatomic) NSArray<NSValue *> *tensorPointerValues;
+@property (strong, nonatomic) NSArray<NSData *> *tensorData;
+@property (strong, nonatomic) NSArray<NSArray<NSNumber *> *> *tensorShapes;
+@property (strong, nonatomic) NSArray<NSNumber *> *types;
+
+- (instancetype)initWithTensorPointerValues:(NSArray<NSValue *> *)tensorPointerValues
+                                 tensorData:(NSArray<NSData *> *)tensorData
+                               tensorShapes:(NSArray<NSArray<NSNumber *> *> *)tensorShapes
+                                      types:(NSArray<NSNumber *> *)types;
+
+@end
 
 @interface TorchTrainingResult: NSObject
 
@@ -27,14 +40,24 @@ NS_SWIFT_NAME(init(fileAtPath:))NS_DESIGNATED_INITIALIZER;
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+//- (TorchTrainingResult *)executeWithTrainingArray:(void *)trainingDataArray
+//     trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
+//     trainingLabels:(void *)trainingLabelArrays
+//trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
+//        paramArrays:(NSArray<NSValue *> *)paramArrays
+//         withShapes:(NSArray<NSArray<NSNumber *> *> *)paramShapes
+//          batchSize:(void *)batchSize
+//       learningRate:(void *)learningRate;
+
 - (TorchTrainingResult *)executeWithTrainingArray:(void *)trainingDataArray
      trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
      trainingLabels:(void *)trainingLabelArrays
 trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
-        paramArrays:(NSArray<NSValue *> *)paramArrays
-         withShapes:(NSArray<NSArray<NSNumber *> *> *)paramShapes
+ paramTensorsHolder:(TensorsHolder *)paramTensorsHolder
           batchSize:(void *)batchSize
        learningRate:(void *)learningRate;
+
+
 
 - (NSArray<NSArray<NSNumber *> *> *)generateDiffFromOriginalParamArrays:(NSArray<NSValue *> *)originalParamArrays
                                                      updatedParamArrays:(NSArray<NSValue *> *)updatedParamArrays

--- a/SwiftSyft/Classes/TorchTrainingModule.h
+++ b/SwiftSyft/Classes/TorchTrainingModule.h
@@ -40,22 +40,15 @@ NS_SWIFT_NAME(init(fileAtPath:))NS_DESIGNATED_INITIALIZER;
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-//- (TorchTrainingResult *)executeWithTrainingArray:(void *)trainingDataArray
-//     trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
-//     trainingLabels:(void *)trainingLabelArrays
-//trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
-//        paramArrays:(NSArray<NSValue *> *)paramArrays
-//         withShapes:(NSArray<NSArray<NSNumber *> *> *)paramShapes
-//          batchSize:(void *)batchSize
-//       learningRate:(void *)learningRate;
-
 - (TorchTrainingResult *)executeWithTrainingArray:(void *)trainingDataArray
-     trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
-     trainingLabels:(void *)trainingLabelArrays
-trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
- paramTensorsHolder:(TensorsHolder *)paramTensorsHolder
-          batchSize:(void *)batchSize
-       learningRate:(void *)learningRate;
+                                   trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
+                                 trainingDataType:(NSInteger)trainingDataTypeInt
+                                   trainingLabels:(void *)trainingLabelArrays
+                              trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
+                                trainingLabelType:(NSInteger)trainingLabelTypeInt
+                               paramTensorsHolder:(TensorsHolder *)paramTensorsHolder
+                                        batchSize:(void *)batchSize
+                                     learningRate:(void *)learningRate;
 
 
 

--- a/SwiftSyft/Classes/TorchTrainingModule.mm
+++ b/SwiftSyft/Classes/TorchTrainingModule.mm
@@ -65,8 +65,10 @@ std::map<int, at::ScalarType> tensorTypeMap = {{1, at::kInt}, {2, at::kInt}, {3,
 
 - (TorchTrainingResult *)executeWithTrainingArray:(void *)trainingDataArray
                                    trainingShapes:(NSArray<NSNumber *> *)trainingDataShapes
+                                 trainingDataType:(int)trainingDataTypeInt
                                    trainingLabels:(void *)trainingLabelArrays
                               trainingLabelShapes:(NSArray<NSNumber *> *)trainingLabelShapes
+                                trainingLabelType:(int)trainingLabelTypeInt
                                paramTensorsHolder:(TensorsHolder *)paramTensorsHolder
                                         batchSize:(void *)batchSize
                                      learningRate:(void *)learningRate {
@@ -81,7 +83,7 @@ std::map<int, at::ScalarType> tensorTypeMap = {{1, at::kInt}, {2, at::kInt}, {3,
         trainingDataVectorShape.push_back([dim integerValue]);
     }
 
-    at::Tensor trainingDataTensor = torch::from_blob(trainingDataArray, trainingDataVectorShape, at::kFloat);
+    at::Tensor trainingDataTensor = torch::from_blob(trainingDataArray, trainingDataVectorShape, tensorTypeMap[trainingDataTypeInt]);
     modelArgs.push_back(trainingDataTensor);
 
     // Push training label vectors
@@ -91,7 +93,7 @@ std::map<int, at::ScalarType> tensorTypeMap = {{1, at::kInt}, {2, at::kInt}, {3,
         trainingLabelVectorShape.push_back([dim integerValue]);
     }
 
-    at::Tensor trainingLabelsTensor = torch::from_blob(trainingLabelArrays, trainingLabelVectorShape, at::kFloat);
+    at::Tensor trainingLabelsTensor = torch::from_blob(trainingLabelArrays, trainingLabelVectorShape, tensorTypeMap[trainingLabelTypeInt]);
 
     modelArgs.push_back(trainingLabelsTensor);
 

--- a/SwiftSyft/Classes/TorchTrainingModule.mm
+++ b/SwiftSyft/Classes/TorchTrainingModule.mm
@@ -8,6 +8,8 @@
 #import "TorchTrainingModule.h"
 #include <LibTorch/LibTorch.h>
 
+std::map<int, at::ScalarType> tensorTypeMap = {{1, at::kInt}, {2, at::kInt}, {3, at::kLong}, {4, at::kFloat}, {5, at::kDouble}};
+
 @implementation TorchTrainingResult
 
 - (instancetype)initWithLoss:(float)loss


### PR DESCRIPTION
This adds mapping from the types declared for training/validation data (user defined) and model parameters (defined from syft proto at runtime) to the available torch tensor types.