### PR TITLE
Updated torch module and chart code for new MNIST example

### DIFF
--- a/Example/SwiftSyft/LossChartViewController.swift
+++ b/Example/SwiftSyft/LossChartViewController.swift
@@ -33,8 +33,8 @@ class LossChartViewController: UIViewController {
 
         let leftAxis = lineChartView.leftAxis
         leftAxis.removeAllLimitLines()
-        leftAxis.axisMaximum = 0.25
-        leftAxis.axisMinimum = 0.15
+        leftAxis.axisMaximum = 2.33
+        leftAxis.axisMinimum = 0.4
         leftAxis.gridLineDashLengths = [5, 5]
         leftAxis.drawLimitLinesBehindDataEnabled = true
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,12 +13,12 @@ PODS:
   - SwiftSyft (0.1.0):
     - GoogleWebRTC (~> 1.1.0)
     - LibTorch (~> 1.5.0)
-    - SyftProto (= 0.4.4)
+    - SyftProto (= 0.4.7)
   - SwiftSyft/Tests (0.1.0):
     - GoogleWebRTC (~> 1.1.0)
     - LibTorch (~> 1.5.0)
-    - SyftProto (= 0.4.4)
-  - SyftProto (0.4.4):
+    - SyftProto (= 0.4.7)
+  - SyftProto (0.4.7):
     - SwiftProtobuf (~> 1.8.0)
 
 DEPENDENCIES:
@@ -46,9 +46,9 @@ SPEC CHECKSUMS:
   LibTorch: 6752ffb58ea396b672a2df6f14970bdbc7219de4
   SwiftLint: 8f5d2f903e1c9bcbc832fd16771e80a263ac6cbb
   SwiftProtobuf: 2cbd9409689b7df170d82a92a33443c8e3e14a70
-  SwiftSyft: b803504e71f63a819ad51e686d14245ad016843b
-  SyftProto: e99313e9fbc4d94d456dcef7ca967254ebf5155e
+  SwiftSyft: e448b082db563c9e2f019c63e328ae09fe609446
+  SyftProto: 4ab6fa7d4e435d3d62a19847c65ed57502127d2a
 
 PODFILE CHECKSUM: c230b5a22b496f49d6d35334a75d3894e9b16f70
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/SwiftSyft.podspec
+++ b/SwiftSyft.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
   s.dependency 'LibTorch', '~> 1.5.0'
   s.dependency 'GoogleWebRTC', '~> 1.1.0'
   #s.dependency 'SyftProto', '0.2.9.a1' # TODO: Change this when official syft-proto comes out
-  s.dependency 'SyftProto', '0.4.4' # TODO: Change this when official syft-proto comes out
+  s.dependency 'SyftProto', '0.4.7' # TODO: Change this when official syft-proto comes out
 
   
   s.test_spec 'Tests' do |test_spec|


### PR DESCRIPTION
## Description
1. MNIST notebook demonstrating federated learning has been updated with changes in how params are passed to the model. Params are now passed as a list of params rather than individual function parameters.

2. Model state protobuff model serialization also has changes in the latest PySyft so I had to modify the param update code.

3. Finally, loss chart y-axis range needed to be modified to fit the correct range of loss generated when training the model.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
