### PR TITLE
docs: fix typos

### DIFF
--- a/Example-Background/SwiftSyft-Background/SceneDelegate.swift
+++ b/Example-Background/SwiftSyft-Background/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {

--- a/SwiftSyft/Classes/SignallingClient.swift
+++ b/SwiftSyft/Classes/SignallingClient.swift
@@ -104,7 +104,7 @@ extension SignallingClient {
 
         #if !DEBUG
         guard url.absoluteString.hasPrefix("wss") else {
-            preconditionFailure("Path for socket server shoud start with wss://")
+            preconditionFailure("Path for socket server should start with wss://")
         }
         #endif
 

--- a/SwiftSyft/Classes/SyftWebSocket.swift
+++ b/SwiftSyft/Classes/SyftWebSocket.swift
@@ -18,7 +18,7 @@ class SyftWebSocket: NSObject, SocketClientProtocol, URLSessionWebSocketDelegate
         super.init()
         #if !DEBUG
         guard url.absoluteString.hasPrefix("wss") else {
-            preconditionFailure("Path for socket server shoud start with wss://")
+            preconditionFailure("Path for socket server should start with wss://")
         }
         #endif
         urlSession = URLSession(configuration: .default, delegate: self, delegateQueue: delegateQueue)


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `Example-Background/SwiftSyft-Background/SceneDelegate.swift`
- 1 typo in `SwiftSyft/Classes/SignallingClient.swift`
- 1 typo in `SwiftSyft/Classes/SyftWebSocket.swift`



Best! :robot: