### PR TITLE
Added overloaded swift operators for TorchTensor

### DIFF
--- a/SwiftSyft/Classes/TorchWrapper/apis/TorchError.h
+++ b/SwiftSyft/Classes/TorchWrapper/apis/TorchError.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+extern NSString * const TorchErrorDomain;
+
+typedef NS_ENUM(NSInteger, TorchError) {
+    TorchTensorOperationError                        = -1000,
+};
+

--- a/SwiftSyft/Classes/TorchWrapper/apis/TorchError.m
+++ b/SwiftSyft/Classes/TorchWrapper/apis/TorchError.m
@@ -1,0 +1,3 @@
+#import <Foundation/Foundation.h>
+
+NSString * const TorchErrorDomain = @"com.pytorch.ios";

--- a/SwiftSyft/Classes/TorchWrapper/apis/TorchTensor.h
+++ b/SwiftSyft/Classes/TorchWrapper/apis/TorchTensor.h
@@ -46,7 +46,13 @@ typedef NS_ENUM(NSUInteger, TorchTensorType) {
                                 Size:(NSArray<NSNumber*>*)size
                                 Type:(TorchTensorType)type;
 
+# pragma mark - TorchTensor operations
+
 - (BOOL)isEqual:(nullable id)object;
+- (nullable TorchTensor *)sub:(TorchTensor *)other error:(NSError **)error;
+- (nullable TorchTensor *)add:(TorchTensor *)other error:(NSError **)error;
+- (nullable TorchTensor *)mul:(TorchTensor *)other error:(NSError **)error;
+- (nullable TorchTensor *)div:(TorchTensor *)other error:(NSError **)error;
 
 + (TorchTensor *)cat:(NSArray<TorchTensor *> *)tensor;
 

--- a/SwiftSyft/Classes/TorchWrapper/src/TorchTensor.mm
+++ b/SwiftSyft/Classes/TorchWrapper/src/TorchTensor.mm
@@ -1,6 +1,7 @@
 #import "TorchTensor.h"
 #import <LibTorch/LibTorch.h>
 #import "TorchTensorPrivate.h"
+#import "TorchError.h"
 
 #define DEFINE_TENSOR_TYPES(_) \
   _(Byte)                      \
@@ -158,5 +159,48 @@ static inline TorchTensorType tensorTypeFromScalarType(c10::ScalarType type) {
     return [self isEqualToTensor:(TorchTensor*)object];
 }
 
+- (TorchTensor *)sub:(TorchTensor *)other error:(NSError **)error {
+    try {
+        at::Tensor result = torch::sub(_impl, other.toTensor);
+        return [TorchTensor newWithTensor:result];
+    } catch (std::exception const& exception) {
+        NSString *errorMessage = [NSString stringWithFormat:@"%s", exception.what()];
+        *error = [NSError errorWithDomain:TorchErrorDomain code:TorchTensorOperationError userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+        return nil;
+    }
+}
+
+- (nullable TorchTensor *)add:(TorchTensor *)other error:(NSError **)error {
+    try {
+        at::Tensor result = torch::add(_impl, other.toTensor);
+        return [TorchTensor newWithTensor:result];
+    } catch (std::exception const& exception) {
+        NSString *errorMessage = [NSString stringWithFormat:@"%s", exception.what()];
+        *error = [NSError errorWithDomain:TorchErrorDomain code:TorchTensorOperationError userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+        return nil;
+    }
+}
+
+- (nullable TorchTensor *)mul:(TorchTensor *)other error:(NSError **)error {
+    try {
+        at::Tensor result = torch::mul(_impl, other.toTensor);
+        return [TorchTensor newWithTensor:result];
+    } catch (std::exception const& exception) {
+        NSString *errorMessage = [NSString stringWithFormat:@"%s", exception.what()];
+        *error = [NSError errorWithDomain:TorchErrorDomain code:TorchTensorOperationError userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+        return nil;
+    }
+}
+
+- (nullable TorchTensor *)div:(TorchTensor *)other error:(NSError **)error {
+    try {
+        at::Tensor result = torch::div(_impl, other.toTensor);
+        return [TorchTensor newWithTensor:result];
+    } catch (std::exception const& exception) {
+        NSString *errorMessage = [NSString stringWithFormat:@"%s", exception.what()];
+        *error = [NSError errorWithDomain:TorchErrorDomain code:TorchTensorOperationError userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+        return nil;
+    }
+}
 
 @end

--- a/SwiftSyft/Extensions/TorchExtensions.swift
+++ b/SwiftSyft/Extensions/TorchExtensions.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension TorchTensor {
+    static func - (lhs: TorchTensor, rhs: TorchTensor) throws -> TorchTensor {
+        return try lhs.sub(rhs)
+    }
+
+    static func + (lhs: TorchTensor, rhs: TorchTensor) throws -> TorchTensor {
+        return try lhs.add(rhs)
+    }
+
+    static func * (lhs: TorchTensor, rhs: TorchTensor) throws -> TorchTensor {
+        return try lhs.mul(rhs)
+    }
+
+    static func / (lhs: TorchTensor, rhs: TorchTensor) throws -> TorchTensor {
+        return try lhs.div(rhs)
+    }
+
+}


### PR DESCRIPTION
Added overloaded swift operators for TorchTensor (addition, multiplication, division, subtraction)

## How has this been tested?
PyTorch 1.6 tensor operations currently cannot run on unit test target.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)

