### PR TITLE
Fix auth error by tweaking model_version for MNIST example app

### DIFF
--- a/Example/SwiftSyft/HomeViewController.swift
+++ b/Example/SwiftSyft/HomeViewController.swift
@@ -89,7 +89,7 @@ class HomeViewController: UIViewController, UITextViewDelegate {
             self.activityIndicator.startAnimating()
 
             // Create a new federated learning job with the model name and version
-            self.syftJob = syftClient.newJob(modelName: "mnist", version: "1.0.0")
+            self.syftJob = syftClient.newJob(modelName: "mnist", version: "1.0")
 
             // This function is called when SwiftSyft has downloaded the plans and model parameters from PyGrid
             // You are ready to train your model on your data


### PR DESCRIPTION
## Description
Fix auth error by tweaking `model_version` for MNIST example app to match that of the corresponding `model-centric` demo [Jupyter notebook](https://github.com/OpenMined/PyGrid/tree/dev/examples/model-centric).

## Affected Dependencies
N/A

## How has this been tested?
- Smoke tested in Xcode 12.0.1 on iOS 14 simulator.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
