### PR TITLE
Changed Xcode used in cocopods release action from default to Xcode 12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   documentation:
 
     runs-on: macos-latest
+    env: 
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     name: Create API documentation
     if: github.event_name == 'release' && !failure()
 
@@ -40,6 +42,8 @@ jobs:
   publish:
     needs: documentation
     runs-on: macos-latest
+    env: 
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     name: Publish this version to Cocoapods
     if: github.event_name == 'release' && !failure()
 


### PR DESCRIPTION
## Description
Changed Xcode used in cocopods release action from default to Xcode 12

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
