### PR TITLE
Added user level build setting for excluding arm64 simulators

### DIFF
--- a/Example/SwiftSyft.xcodeproj/project.pbxproj
+++ b/Example/SwiftSyft.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		BE4D0A5F2453302E0013DD79 /* LossChartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LossChartViewController.swift; sourceTree = "<group>"; };
-		BED313F624B70495005F2E95 /* OpenMinedSwiftSyft.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; fileEncoding = 4; name = OpenMinedSwiftSyft.podspec; path = ../OpenMinedSwiftSyft.podspec; sourceTree = "<group>"; };
+		BED313F624B70495005F2E95 /* OpenMinedSwiftSyft.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; fileEncoding = 4; name = OpenMinedSwiftSyft.podspec; path = ../OpenMinedSwiftSyft.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BEDCA177243236FC007747A5 /* train-images-idx3-ubyte */ = {isa = PBXFileReference; lastKnownFileType = file; path = "train-images-idx3-ubyte"; sourceTree = "<group>"; };
 		BEDCA178243236FC007747A5 /* t10k-labels-idx1-ubyte */ = {isa = PBXFileReference; lastKnownFileType = file; path = "t10k-labels-idx1-ubyte"; sourceTree = "<group>"; };
 		BEDCA179243236FC007747A5 /* t10k-images-idx3-ubyte */ = {isa = PBXFileReference; lastKnownFileType = file; path = "t10k-images-idx3-ubyte"; sourceTree = "<group>"; };

--- a/OpenMinedSwiftSyft.podspec
+++ b/OpenMinedSwiftSyft.podspec
@@ -35,6 +35,8 @@ Pod::Spec.new do |s|
   s.source_files = 'SwiftSyft/**/*'
   s.static_framework = true
 
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/LibTorch/install/include"',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,11 +21,11 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.0.0)
   - OHHTTPStubs/Swift (9.0.0):
     - OHHTTPStubs/Default
-  - OpenMinedSwiftSyft (0.1.3-beta1):
+  - OpenMinedSwiftSyft (0.1.3-beta2):
     - GoogleWebRTC (~> 1.1.0)
     - LibTorch (~> 1.6.1)
     - SyftProto (= 0.4.9)
-  - OpenMinedSwiftSyft/Tests (0.1.3-beta1):
+  - OpenMinedSwiftSyft/Tests (0.1.3-beta2):
     - GoogleWebRTC (~> 1.1.0)
     - LibTorch (~> 1.6.1)
     - OHHTTPStubs/Swift
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   GoogleWebRTC: cfb83bc346435a17fe06bb05f04ad826b858a7fb
   LibTorch: 32a83630ab5b4505f205c7e332975a2d3d6e0c55
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
-  OpenMinedSwiftSyft: ae7db71eca1f76c11705c174e835927bb371d62c
+  OpenMinedSwiftSyft: 763cce92a26eecfa98e1598716e8507cab1e413a
   SwiftLint: 8f5d2f903e1c9bcbc832fd16771e80a263ac6cbb
   SwiftProtobuf: 2cbd9409689b7df170d82a92a33443c8e3e14a70
   SyftProto: da02767fd695d222748d6bdf78ff7ddbe7b1982f


### PR DESCRIPTION
This is needed due to pod dependencies that don't exclude the arm64 simulators themselves (libtorch, GoogleWebRTC ...)

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
